### PR TITLE
[정리] 기존 남은 지뢰 개수 표시 기능 동작 확인 #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+## Minesweeper Contribution Log
+
+### Issue #5
+- Confirmed that the remaining mine counter feature was already implemented.
+- Mines value updates correctly based on flagged cells.
+- No functional changes were required.


### PR DESCRIPTION
- 남은 지뢰 개수(Mines) 표시 기능이 기존 코드에 이미 구현되어 있음을 확인했습니다.

- 깃발 수에 따라 Mines 값이 정상적으로 감소/증가합니다.
- 음수로 표시되지 않도록 처리되어 있습니다.
- UI 상단에 실시간으로 반영됩니다.

정리
- 기능 추가는 없으며, 기존 구현을 검증하고 문서로 정리했습니다.

Fixes #5
